### PR TITLE
Added null check to prevent a crash when removing button twice in a row.

### DIFF
--- a/phial-overlay/src/main/java/com/mindcoders/phial/internal/overlay/OverlayView.java
+++ b/phial-overlay/src/main/java/com/mindcoders/phial/internal/overlay/OverlayView.java
@@ -82,8 +82,11 @@ class OverlayView implements ExpandedView.ExpandedViewCallback {
 
     void removeButton(Activity activity) {
         final View button = buttons.remove(activity);
-        dragHelper.unmanage(button);
-        activity.getWindowManager().removeView(button);
+
+        if (button != null){
+            dragHelper.unmanage(button);
+            activity.getWindowManager().removeView(button);
+        }
     }
 
     void showExpandedView(Activity activity, List<Page> pages, Page selected, boolean animated) {

--- a/phial-overlay/src/test/java/com/mindcoders/phial/internal/overlay/OverlayViewTest.java
+++ b/phial-overlay/src/test/java/com/mindcoders/phial/internal/overlay/OverlayViewTest.java
@@ -11,7 +11,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Matchers;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
@@ -23,6 +25,7 @@ import java.util.stream.IntStream;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -64,6 +67,16 @@ public class OverlayViewTest {
         verify(dragHelper).animateFromDefaultPosition(eq(viewArgumentCaptor.getValue()), any());
         view.removeButton(activity);
         verify(windowManager).removeView(viewArgumentCaptor.getValue());
+    }
+
+    @Test
+    public void remove_twice_the_same_no_crash() {
+        view.showButton(activity, true);
+
+        view.removeButton(activity);
+        view.removeButton(activity);
+
+        verify(dragHelper, Mockito.never()).unmanage(Matchers.isNull(View.class));
     }
 
     @Test


### PR DESCRIPTION
The root of the issue is that button is being removed twice, causing NullPointerException on the second removal.
It is so because button is removed from the map on `OverlayPresenter#onButtonMoved()` at first normally, then activity is stopped, causing the button to be removed again on `OverlayPresenter#onActivityStopped(Activity activity)`. As it seems that both calls are expected simple null check will have suffice here to prevent an unhandled exception that crash the app.